### PR TITLE
Uplift to newer V8 API and fix bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,13 @@
 'use strict';
 
-module.exports = require('./build/Release/cppmap').WeakValueMap;
+const fs = require("fs");
+
+if (fs.existsSync('./build/Release/cppmap.node')) {
+    module.exports = require('./build/Release/cppmap').WeakValueMap;
+} else if (fs.existsSync('./build/Debug/cppmap.node')) {
+    console.log("weak-value-map loaded debug build");
+    module.exports = require('./build/Debug/cppmap').WeakValueMap;
+} else {
+    console.error("weak-value-map not built!");
+    process.exit(1);
+}

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const fs = require("fs");
+const fs = require('fs');
+const path = require('path');
 
-if (fs.existsSync('./build/Release/cppmap.node')) {
+if (fs.existsSync(path.join(__dirname, 'build/Release/cppmap.node'))) {
     module.exports = require('./build/Release/cppmap').WeakValueMap;
-} else if (fs.existsSync('./build/Debug/cppmap.node')) {
+} else if (fs.existsSync(path.join(__dirname, 'build/Debug/cppmap.node'))) {
     console.log("weak-value-map loaded debug build");
     module.exports = require('./build/Debug/cppmap').WeakValueMap;
 } else {

--- a/map.cc
+++ b/map.cc
@@ -1,20 +1,36 @@
 #include <node.h>
 #include <node_object_wrap.h>
 #include <unordered_map>
+#include <cstdint>
 
 struct WeakValue;
 
 typedef std::pair<std::unordered_map<std::string, WeakValue>*, std::string> MapKeyPair;
+typedef std::uint64_t InstanceId_t;
+typedef std::unordered_map<InstanceId_t, bool> InstanceIdMap;
+
+struct FinalizationCbData {
+	InstanceId_t weakValueMapInstanceId;
+	MapKeyPair* pair;
+
+	FinalizationCbData(InstanceId_t weakValueMapInstanceId, MapKeyPair* pair)
+		: weakValueMapInstanceId(weakValueMapInstanceId), pair(pair) {
+	}
+	~FinalizationCbData() {}
+};
 
 struct WeakValue {
 	MapKeyPair* pair = nullptr;
 	v8::UniquePersistent<v8::Value> value;
-	WeakValue(std::unordered_map<std::string, WeakValue>* m, std::string s, v8::UniquePersistent<v8::Value>&& v)  : value(std::move(v)) {
+	WeakValue(std::unordered_map<std::string, WeakValue>* m, std::string s, v8::UniquePersistent<v8::Value>&& v)
+		: value(std::move(v)) {
 		this->pair = new MapKeyPair(m, s);
 	}
 	~WeakValue() {
-		if (this->pair != nullptr)
+		if (this->pair != nullptr) {
 			delete this->pair;
+			this->pair = nullptr;
+		}
 	}
 	WeakValue() { }
 	WeakValue(WeakValue&& o) {
@@ -40,15 +56,22 @@ public:
 
 		constructor.Reset(isolate, tpl->GetFunction());
 		exports->Set(v8::String::NewFromUtf8(isolate, "WeakValueMap"), tpl->GetFunction());
+
+		WeakValueMap::instanceId = 0;
+		WeakValueMap::instanceMap = new InstanceIdMap();
 	}
 
 private:
 	explicit WeakValueMap() {
 		this->map = new std::unordered_map<std::string, WeakValue>;
+		this->id = WeakValueMap::instanceId++;
+		WeakValueMap::instanceMap->insert(std::make_pair(this->id, true));
 	}
 
 	~WeakValueMap() {
 		delete this->map;
+		this->map = nullptr;
+		WeakValueMap::instanceMap->erase(this->id);
 	}
 
 	static void New(const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -63,6 +86,17 @@ private:
 		}
 	}
 
+	static void finalizationCb(const v8::WeakCallbackInfo<FinalizationCbData>& data) {
+		auto d = data.GetParameter();
+		auto id = d->weakValueMapInstanceId;
+		// Check that WeakValueMap hasn't been deleted
+		if (WeakValueMap::instanceMap->count(id) != 0) {
+			auto p = d->pair;
+			p->first->erase(p->second);
+		}
+		delete d;
+	};
+
 	static void Set(const v8::FunctionCallbackInfo<v8::Value>& args) {
 		v8::Isolate* isolate = args.GetIsolate();
 
@@ -75,12 +109,8 @@ private:
 		v8::UniquePersistent<v8::Value> value(isolate, args[1]);
 
 		WeakValue val(obj->map, key, std::move(value));
-
-		auto finalizationCb = [](const v8::WeakCallbackInfo<MapKeyPair>& data) {
-			auto p = data.GetParameter();
-			p->first->erase(p->second);
-		};
-		val.value.SetWeak(val.pair, finalizationCb, v8::WeakCallbackType::kParameter);
+		FinalizationCbData* cbData = new FinalizationCbData(obj->id, val.pair);
+		val.value.SetWeak(cbData, WeakValueMap::finalizationCb, v8::WeakCallbackType::kParameter);
 		obj->map->insert(std::make_pair(key, std::move(val)));
 
 		args.GetReturnValue().Set(args.Holder());
@@ -105,10 +135,16 @@ private:
 	}
 
 	static v8::Persistent<v8::Function> constructor;
+	static InstanceId_t instanceId;
+	static InstanceIdMap* instanceMap;
 
+	InstanceId_t id;
 	std::unordered_map<std::string, WeakValue>* map;
 };
 
 v8::Persistent<v8::Function> WeakValueMap::constructor;
+
+InstanceIdMap* WeakValueMap::instanceMap;
+InstanceId_t WeakValueMap::instanceId;
 
 NODE_MODULE(addon, WeakValueMap::Init)

--- a/map.cc
+++ b/map.cc
@@ -76,10 +76,11 @@ private:
 
 		WeakValue val(obj->map, key, std::move(value));
 
-		val.value.SetWeak(val.pair, [](const v8::WeakCallbackData<v8::Value, MapKeyPair>& data) {
+		auto finalizationCb = [](const v8::WeakCallbackInfo<MapKeyPair>& data) {
 			auto p = data.GetParameter();
 			p->first->erase(p->second);
-		});
+		};
+		val.value.SetWeak(val.pair, finalizationCb, v8::WeakCallbackType::kParameter);
 		obj->map->insert(std::make_pair(key, std::move(val)));
 
 		args.GetReturnValue().Set(args.Holder());


### PR DESCRIPTION
Please incorporate these changes:
- Uplift to new V8 API due to https://codereview.chromium.org/1953263002
- Fix a bug that happens when GC frees a JS object after the WeakValueMap has been deleted. In this case the finalization callback dereferences freed memory.