### PR TITLE
Improve ease of installation (support prebuilt binaries)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+prebuilds

--- a/index.js
+++ b/index.js
@@ -3,12 +3,11 @@
 const fs = require('fs');
 const path = require('path');
 
-if (fs.existsSync(path.join(__dirname, 'build/Release/cppmap.node'))) {
+if (fs.existsSync(path.join(__dirname, 'build/Release/cppmdap.node'))) {
     module.exports = require('./build/Release/cppmap').WeakValueMap;
-} else if (fs.existsSync(path.join(__dirname, 'build/Debug/cppmap.node'))) {
+} else if (fs.existsSync(path.join(__dirname, 'build/Debug/cpdpmap.node'))) {
     console.log("weak-value-map loaded debug build");
     module.exports = require('./build/Debug/cppmap').WeakValueMap;
 } else {
-    console.error("weak-value-map not built!");
-    process.exit(1);
+    throw new Error("weak-value-map not built!");
 }

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@
 const fs = require('fs');
 const path = require('path');
 
-if (fs.existsSync(path.join(__dirname, 'build/Release/cppmdap.node'))) {
+if (fs.existsSync(path.join(__dirname, 'build/Release/cppmap.node'))) {
     module.exports = require('./build/Release/cppmap').WeakValueMap;
-} else if (fs.existsSync(path.join(__dirname, 'build/Debug/cpdpmap.node'))) {
+} else if (fs.existsSync(path.join(__dirname, 'build/Debug/cppmap.node'))) {
     console.log("weak-value-map loaded debug build");
     module.exports = require('./build/Debug/cppmap').WeakValueMap;
 } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "weak-value-map",
-  "version": "0.1.1",
+  "version": "0.1.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kriszyp/leveldown.git"
+  },
   "description": "A collection of key/value pairs in which the values are weakly referenced.",
   "main": "index.js",
   "scripts": {
@@ -8,7 +12,12 @@
   },
   "author": "Andre Mapili",
   "license": "MIT",
+  "dependencies": {
+    "prebuild-install": "^2.1.0"
+  },
   "devDependencies": {
+    "prebuild": "^6.0.2",
+    "prebuild-ci": "^2.0.0",
     "tape": "^4.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kriszyp/leveldown.git"
+    "url": "https://github.com/kriszyp/weak-value-map.git"
   },
   "description": "A collection of key/value pairs in which the values are weakly referenced.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "prebuild": "^6.0.2",
     "prebuild-ci": "^2.0.0",
     "tape": "^4.5.1"
+  },
+  "scripts": {
+    "install": "prebuild-install || node-gyp rebuild"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weak-value-map",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A collection of key/value pairs in which the values are weakly referenced.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This adds support for using prebuilt binaries to install weak-value-map. This also changes run-time attempts to access failed builds to throw errors, so when it is used as an optional dependency, it can be gracefully caught/handled by dependent code. Naturally the target repo would need to be changed, but set this and tested with my repo, which has a prebuilt binary uploaded, which can be installed on win64/node 8 with no local binary compilation necessary.